### PR TITLE
Fix to compile on GNU g++

### DIFF
--- a/src/evaluation.h
+++ b/src/evaluation.h
@@ -15,7 +15,7 @@ class EvalNode {
     public:
     using Ptr = std::shared_ptr<EvalNode>;
     double calc() {
-        if (isnan(d_cachedValue) || needCalc()) {
+        if (std::isnan(d_cachedValue) || needCalc()) {
             auto value = eval();
             d_cachedValue = value;
             return value;
@@ -69,7 +69,7 @@ class VariableNode: public EvalNode {
     public:
     using Ptr = std::shared_ptr<VariableNode>;
     virtual double eval() {
-        if (isnan(d_value)) {
+        if (std::isnan(d_value)) {
             throw std::runtime_error("Variable not set");
         } else {
             return d_value;


### PR DESCRIPTION
With g++ 5.3.0, I get the following error without the change.  By the way,  the calls to `nan(...)` calls the C99 version of the function, not the C++.

> /home/gnoel/github/evaluation/src/evaluation.h:18:32: error: 'isnan' was not declared in this scope
